### PR TITLE
build: fix entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,13 @@ If you're not interested in the code, and just want to deploy it to kick the typ
 ## Running the container
 Once you've built the container locally, you can test it like this (assumes you built it with a *test* tag);  
 ```
-podman run -d --network=host --name proctest -v /proc:/host/proc:ro --privileged --entrypoint=/process-exporter
- localhost/process-exporter:test -debug -filter=kwin_x11
+podman run -d --network=host --name proctest -v /proc:/host/proc:ro --user 65534 localhost/process-exporter:test -debug -filter=kwin_x11
 ```
-Note that we need to run the container in **privileged** mode to read the contents of procfs from a container.
 
 Here's an example looking at ceph osd and mgr processes, using the prebuilt container
   
 ```
-podman run -d --rm --network=host --name proc-exporter -v /proc:/host/proc:ro --privileged --entrypoint=/process-exporter docker.io/pcuzner/process-exporter:latest -debug -filter=ceph-osd,ceph-mgr -with-threads -prefix=ceph
+podman run -d --rm --network=host --name proc-exporter -v /proc:/host/proc:ro --user 65534 docker.io/pcuzner/process-exporter:latest -debug -filter=ceph-osd,ceph-mgr -with-threads -prefix=ceph
 ```
 
 ## Visualisations

--- a/buildah/build-exporter.sh
+++ b/buildah/build-exporter.sh
@@ -23,7 +23,7 @@ buildah run -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 -- $build go build .
 container=$(buildah from "laptop:5000/alpine:3.17")
 buildah config --workingdir / $container
 buildah copy --from $build $container /process-exporter/process-exporter /process-exporter
-buildah config --entrypoint "/process-exporter" $container
+buildah config --entrypoint '["/process-exporter"]' $container
 
 buildah config --label maintainer="Paul Cuzner <pcuzner@ibm.com>" $container
 buildah config --label description="Process exporter" $container


### PR DESCRIPTION
Entrypoint has two forms: exec and shell form. When it uses shell form, the parameters passed on podman
run are ignored. This change switches to exec form which honours the parameters passed to the container.

Fixes #1
Fixes #2