### PR TITLE
Improve thread gathering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Usage of ./process-exporter:
   -prefix string
         prefix to use for the metric names returned to Prometheus (default "proc")
   -with-threads
-        include thread cpu stats for processes that match the filter 
+        process names to include thread level statistics for (can be a comma separated list) 
 ```
 
-Although the ```-with-threads option``` is useful for diagnostics, if you're monitoring many processes that use high numbers of threads, you should consider the cardinality impact to the Prometheus Server before enabling. If your unsure how many threads your processes are using, you can use the  ```*_process_thread_total``` metric to help determine the impact of enabling thread collection.
+Use the ```-with-threads``` carefully. If you're monitoring many processes that use high numbers of threads, you may cause a cardinality issue for the Prometheus Server. If your unsure how many threads your processes are using, you can use the  ```*_process_thread_total``` metric to help determine the impact of enabling thread for a specific process or group of processes.
 
 ## Metrics Example
 The metrics below show the format returned when running the exporter within a Ceph cluster

--- a/buildah/build-exporter.sh
+++ b/buildah/build-exporter.sh
@@ -12,15 +12,15 @@ echo "Build image with the tag: $TAG"
 
 # podman pull the image first, push to your local registry to speed up local builds
 #IMAGE="docker.io/golang:1.19"
-IMAGE="laptop:5000/golang:1.19"
+IMAGE="localhost:5000/golang:1.19"
 build=$(buildah from $IMAGE)
 buildah add $build ../src /process-exporter
 buildah config --workingdir /process-exporter $build
 buildah run -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 -- $build go build .
 
-# as above, grab the alpine image first and push to a local registry
-#container=$(buildah from "docker.io/alpine:3.17")
-container=$(buildah from "laptop:5000/alpine:3.17")
+# as above, grab the alpine image first and push to a local registry (was 3.17)
+#container=$(buildah from "docker.io/alpine:3.19")
+container=$(buildah from "localhost:5000/alpine:3.19")
 buildah config --workingdir / $container
 buildah copy --from $build $container /process-exporter/process-exporter /process-exporter
 buildah config --entrypoint '["/process-exporter"]' $container

--- a/src/collector/collector.go
+++ b/src/collector/collector.go
@@ -117,7 +117,7 @@ func (tCollector *threadCollector) Collect(ch chan<- prometheus.Metric) {
 	log.Debug("Collect called")
 	start := time.Now()
 
-	matchingProcs, fetchThreads := GetProcs(tCollector.config.Filter, tCollector.config.WithThreads)
+	matchingProcs := GetProcs(tCollector.config.Filter, tCollector.config.WithThreads)
 	elapsed := time.Since(start)
 	log.Debugf("Looking for matching procs took: %s", elapsed)
 
@@ -133,20 +133,16 @@ func (tCollector *threadCollector) Collect(ch chan<- prometheus.Metric) {
 
 	start = time.Now()
 	var wg sync.WaitGroup
-	idx := 0
-	log.Debug(fetchThreads)
 
 	procChannel := make(chan []defaults.ProcInfo, len(matchingProcs))
 	wg.Add(len(matchingProcs))
 
 	log.Debugf("Starting %d goroutines to gather the data", len(matchingProcs))
-	for _, proc := range matchingProcs {
-		fetchThreadData := fetchThreads[idx]
-		if fetchThreadData {
-			log.Debug("requesting thread stats")
+	for _, procData := range matchingProcs {
+		if procData.withThreads {
+			log.Debug("requesting thread stats for ", procData.comm)
 		}
-		GetProcInfo(proc, fetchThreadData, procChannel, &wg)
-		idx++
+		GetProcInfo(procData.procInfo, procData.withThreads, procChannel, &wg)
 	}
 	wg.Wait()
 	close(procChannel)

--- a/src/collector/procs.go
+++ b/src/collector/procs.go
@@ -28,9 +28,11 @@ func init() {
 }
 
 // GetProcs returns a slice of Proc structs (pids) that match a given name
-func GetProcs(filter string) procfs.Procs {
+func GetProcs(filter string, withThreads string) (procfs.Procs, []bool) {
 	targets := strings.Split(filter, ",")
+	threadProcesses := strings.Split(withThreads, ",")
 	var matchingProcs procfs.Procs
+	var fetchThreadData []bool
 
 	procs, err := FS.AllProcs()
 
@@ -42,9 +44,15 @@ func GetProcs(filter string) procfs.Procs {
 		c, _ := proc.Comm()
 		if utils.Contains(targets, c) {
 			matchingProcs = append(matchingProcs, proc)
+			matchForThreads := utils.Contains(threadProcesses, c)
+			if matchForThreads {
+				log.Debug("Will provide thread statistics for ", c)
+			}
+			fetchThreadData = append(fetchThreadData, matchForThreads)
 		}
+
 	}
-	return matchingProcs
+	return matchingProcs, fetchThreadData
 }
 
 // GetProcInfo runs as a goroutine to gather the proc information for a given proc

--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -11,11 +11,11 @@ var DefaultPort int = 9200
 // exposes this value as a number of pages, so this multiplier converts the pages to bytes.
 var SystemPageSize int = 4096
 
-// Config holds the runtime options to governhow the process-exporter will run
+// Config holds the runtime options to govern how the process-exporter will run
 type Config struct {
 	Filter       string
 	NoMatchAbort bool
-	WithThreads  bool
+	WithThreads  string
 	MetricPrefix string
 }
 

--- a/src/process-exporter.go
+++ b/src/process-exporter.go
@@ -28,11 +28,13 @@ func init() {
 
 func main() {
 	var filter *string
+	var withThreads *string
 	port := flag.Int("port", defaults.DefaultPort, "port for the exporter to bind to")
 	filter = flag.String("filter", "", "command of the process to search for (can be a comma separated list)")
+	withThreads = flag.String("with-threads", "", "process names that should include per thread statistics (can be a comma separated list)")
 	debug := flag.Bool("debug", true, "run in debug mode")
 	noMatchAbort := flag.Bool("nomatch-abort", false, "shutdown if the filter doesn't match any active process")
-	withThreads := flag.Bool("with-threads", false, "include thread cpu stats for processes that match the filter")
+
 	metricPrefix := flag.String("prefix", "proc", "prefix to use for the metric names returned to Prometheus")
 
 	flag.Parse()


### PR DESCRIPTION
Instead of a simple bool to detemine when thread level stats are required, with-threads now takes a string of process names, so you can be more pinpoint about which daemons you want to analyse. This reduces the overheads to prometheus and helps to control the scrape time of the exporter.